### PR TITLE
Fix garbled agent terminal: set the pty winsize directly on Apple silicon

### DIFF
--- a/apps/terminal/Pty/PtyProcess.cs
+++ b/apps/terminal/Pty/PtyProcess.cs
@@ -114,7 +114,11 @@ public sealed class PtyProcess : IPty
     {
         try
         {
-            CurrentConnection()?.Resize(cols, rows);
+            var active = CurrentConnection();
+            if (active is not null && !PtyWindowSize.TrySet(active, cols, rows))
+            {
+                active.Resize(cols, rows);
+            }
         }
         catch
         {

--- a/apps/terminal/Pty/PtyWindowSize.cs
+++ b/apps/terminal/Pty/PtyWindowSize.cs
@@ -1,0 +1,76 @@
+using System.Runtime.InteropServices;
+using Pty.Net;
+
+namespace JobPilot.Terminal.Pty;
+
+/// <summary>
+/// Sets the pty winsize directly on Apple silicon, where Pty.Net's own <c>Resize</c> corrupts it.
+/// </summary>
+/// <remarks>
+/// libc's <c>ioctl</c> is variadic. Apple's arm64 ABI passes variadic arguments on the stack while the
+/// first eight fixed arguments use x0-x7, so Pty.Net's three-argument P/Invoke leaves the winsize pointer
+/// in a register and the kernel reads whatever the stack held - the child gets a random size (~28000 cols)
+/// and every TUI repaint wraps against it. Padding to nine arguments puts the pointer back on the stack.
+/// Every other target passes varargs in registers, where that padding would itself be wrong, so they keep
+/// Pty.Net's implementation.
+/// </remarks>
+internal static class PtyWindowSize
+{
+    private static readonly bool NeedsManualResize =
+        OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+
+    /// <summary>_IOW('t', 103, struct winsize) on Darwin.</summary>
+    private const ulong TIOCSWINSZ = 0x80087467;
+
+    /// <summary>Applies the size, or returns false to fall back to Pty.Net's resize.</summary>
+    internal static bool TrySet(IPtyConnection connection, int cols, int rows)
+    {
+        // A size outside ushort would silently wrap into a plausible-looking winsize.
+        if (!NeedsManualResize || cols is <= 0 or > ushort.MaxValue || rows is <= 0 or > ushort.MaxValue)
+        {
+            return false;
+        }
+
+        // Pty.Net's Unix streams wrap the pty controller itself, so this handle is the fd to resize.
+        if (connection.ReaderStream is not FileStream { SafeFileHandle: { IsInvalid: false, IsClosed: false } handle })
+        {
+            return false;
+        }
+
+        var size = new WinSize { Rows = (ushort)rows, Cols = (ushort)cols };
+        var referenced = false;
+        try
+        {
+            handle.DangerousAddRef(ref referenced);
+            return Ioctl((int)handle.DangerousGetHandle(), TIOCSWINSZ, 0, 0, 0, 0, 0, 0, ref size) == 0;
+        }
+        finally
+        {
+            if (referenced)
+            {
+                handle.DangerousRelease();
+            }
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+    private static extern int Ioctl(
+        int fd,
+        ulong request,
+        nint pad2,
+        nint pad3,
+        nint pad4,
+        nint pad5,
+        nint pad6,
+        nint pad7,
+        ref WinSize size);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WinSize
+    {
+        public ushort Rows;
+        public ushort Cols;
+        public ushort PixelWidth;
+        public ushort PixelHeight;
+    }
+}

--- a/tests/JobPilot.Terminal.Tests/Pty/PtyWindowSizeTests.cs
+++ b/tests/JobPilot.Terminal.Tests/Pty/PtyWindowSizeTests.cs
@@ -1,0 +1,103 @@
+using System.Runtime.InteropServices;
+using JobPilot.Terminal.Pty;
+using Microsoft.Win32.SafeHandles;
+using Pty.Net;
+using Xunit;
+
+namespace JobPilot.Terminal.Tests;
+
+/// <summary>
+/// Regression tests for the garbled agent panel: Pty.Net's Resize left the child with a ~28000-column
+/// winsize on Apple silicon, so Claude Code's TUI wrapped and repainted against a size no one could see.
+/// These drive a real pty master rather than a child process - forking under the parallel suite hangs
+/// before exec, so the end-to-end check against a live session is a manual one.
+/// </summary>
+public sealed class PtyWindowSizeTests
+{
+    private const int Cols = 100;
+    private const int Rows = 30;
+
+    /// <summary>_IOR('t', 104, struct winsize) on Darwin.</summary>
+    private const ulong TIOCGWINSZ = 0x40087468;
+
+    /// <summary>The fake's streams aren't pty fds, so every platform takes the fallback here.</summary>
+    [Fact]
+    public void FallsBackToPtyNet_WhenTheStreamIsNotAPtyFileDescriptor()
+    {
+        var connection = new FakePtyConnection();
+        using var pty = new PtyProcess(_ => connection);
+        pty.Start("claude", [], ".", 80, 24);
+
+        pty.Resize(Cols, Rows);
+
+        Assert.Equal(1, connection.ResizeCalls);
+    }
+
+    [Fact]
+    public void SetsTheWinsizeTheKernelActuallyStores()
+    {
+        // The manual TIOCSWINSZ path only replaces Pty.Net's resize on Apple silicon.
+        if (!OperatingSystem.IsMacOS() || RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+        {
+            return;
+        }
+
+        Assert.Equal(0, OpenPty(out var master, out var replica, 0, 0, 0));
+        using var replicaHandle = new SafeFileHandle(replica, ownsHandle: true);
+        using var handle = new SafeFileHandle(master, ownsHandle: true);
+        using var stream = new FileStream(handle, FileAccess.ReadWrite);
+
+        Assert.True(PtyWindowSize.TrySet(new PtyMaster(stream), Cols, Rows));
+
+        var size = default(WinSize);
+        Assert.Equal(0, Ioctl(master, TIOCGWINSZ, 0, 0, 0, 0, 0, 0, ref size));
+        Assert.Equal(Rows, size.Rows);
+        Assert.Equal(Cols, size.Cols);
+    }
+
+    [DllImport("libc", EntryPoint = "openpty", SetLastError = true)]
+    private static extern int OpenPty(out int master, out int replica, nint name, nint termios, nint winsize);
+
+    /// <summary>Padded like the code under test; Apple's arm64 ABI passes varargs on the stack.</summary>
+    [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+    private static extern int Ioctl(
+        int fd, ulong request, nint p2, nint p3, nint p4, nint p5, nint p6, nint p7, ref WinSize size);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WinSize
+    {
+        public ushort Rows;
+        public ushort Cols;
+        public ushort PixelWidth;
+        public ushort PixelHeight;
+    }
+
+    /// <summary>Presents a pty master fd the way Pty.Net's Unix connection does.</summary>
+    private sealed class PtyMaster(Stream stream) : IPtyConnection
+    {
+#pragma warning disable CS0067 // Nothing in this test waits on a child.
+        public event EventHandler<PtyExitedEventArgs>? ProcessExited;
+#pragma warning restore CS0067
+
+        public Stream ReaderStream => stream;
+
+        public Stream WriterStream => stream;
+
+        public int Pid => 0;
+
+        public int ExitCode => 0;
+
+        public bool WaitForExit(int milliseconds) => true;
+
+        public void Kill()
+        {
+        }
+
+        public void Resize(int cols, int rows) => throw new InvalidOperationException(
+            "The manual TIOCSWINSZ path must not fall back to Pty.Net for a real pty master.");
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/JobPilot.Terminal.Tests/Support/FakePtyConnection.cs
+++ b/tests/JobPilot.Terminal.Tests/Support/FakePtyConnection.cs
@@ -26,6 +26,8 @@ internal sealed class FakePtyConnection : IPtyConnection
 
     public int DisposeCalls { get; private set; }
 
+    public int ResizeCalls { get; private set; }
+
     public Stream ReaderStream => Reader;
 
     public Stream WriterStream => Writer;
@@ -56,6 +58,7 @@ internal sealed class FakePtyConnection : IPtyConnection
 
     public void Resize(int cols, int rows)
     {
+        ResizeCalls++;
         if (ResizeThrows)
         {
             throw new InvalidOperationException("Resizing terminal failed with error 5");


### PR DESCRIPTION
Fixes #23.

`Quick.PtyNet`'s `Resize()` sets a garbage winsize on macOS/arm64, so the agent's TUI lays out against a viewport ~28000 columns wide inside a ~79-column panel. Every repaint wraps at the wrong points and overprints the last one, which is what reads as two interleaved output streams.

`ioctl(2)` is variadic, and Apple's arm64 ABI passes variadic arguments on the stack while fixed arguments use `x0`-`x7`. Pty.Net's three-fixed-argument P/Invoke leaves the `winsize*` in a register, so the kernel copies whatever the stack held. It returns `0`, so the failure is silent. `forkpty` takes a genuine non-variadic `ref winsize`, which is why the spawn size is always correct and only later resizes corrupt it - and the web panel sends a resize as soon as the socket opens, so every session broke immediately after connect.

Filed against the library as aaasoft/Quick.PtyNet#2; this is the host-side fix while that is outstanding.

### The change

`PtyWindowSize` issues `TIOCSWINSZ` itself with the pointer padded onto the stack, and `PtyProcess.Resize` falls back to Pty.Net whenever the guard declines.

- **Gated to macOS/arm64.** Every other target passes varargs in registers, where the padding would itself be wrong, so they keep the library's implementation untouched. `Linux/PtyConnection.cs` has the same shape upstream but is not affected.
- **No reflection.** The master fd comes from `ReaderStream`'s `SafeFileHandle` - Pty.Net's Unix streams wrap the pty controller itself. That matters because the host is `PublishAot` and trimming can drop reflected private fields.

### Verification

End to end against a running host, driving a real resize over the WebSocket:

```
before:  7008 28917     # stty -f /dev/ttysNNN size (rows cols)
after:   30 100         # exactly what was requested
```

239 tests pass. The new test drives a real pty master and reads the size back with `TIOCGWINSZ`; removing the padding makes it fail, so it is a real regression guard. It deliberately does not spawn a child process - forking under the parallel xunit suite hangs before `exec`.

### Note on the earlier diagnosis

I originally reported the cause as two xterm layers on one container. That was wrong, and I have corrected it in #23. This PR does **not** include the defensive `terminal-panel.tsx` changes from that theory, nor a `reactStrictMode: false` workaround I had applied locally - with the winsize fixed, neither is needed, and disabling StrictMode upstream would cost a useful dev check for no reason.
