### PR TITLE
Block a second application to a job already applied to

### DIFF
--- a/apps/api/prisma/migrations/20260808000000_canonicalize_hiring_cafe_urls/migration.sql
+++ b/apps/api/prisma/migrations/20260808000000_canonicalize_hiring_cafe_urls/migration.sql
@@ -1,0 +1,28 @@
+-- hiring.cafe began serving the same postings from hiringcafe.com with byte-identical paths, so
+-- the unique (user_id, url) pair saw one posting as two rows and let a second real application go
+-- out. Fold the legacy host onto the canonical one so those rows dedupe against new applications.
+--
+-- Rows whose canonical URL is already taken are left on the legacy host on purpose: that pair is a
+-- duplicate that really was submitted twice, and rewriting would either break the unique index or
+-- destroy the record of an application that actually happened.
+
+UPDATE applications a
+SET url = 'https://hiringcafe.com/' || substring(a.url FROM length('https://hiring.cafe/') + 1)
+WHERE a.url LIKE 'https://hiring.cafe/%'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM applications b
+    WHERE b.user_id = a.user_id
+      AND b.url = 'https://hiringcafe.com/' || substring(a.url FROM length('https://hiring.cafe/') + 1)
+  );
+
+UPDATE applications a
+SET url = 'https://hiringcafe.com/' || substring(a.url FROM length('https://www.hiringcafe.com/') + 1)
+WHERE a.url LIKE 'https://www.hiringcafe.com/%'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM applications b
+    WHERE b.user_id = a.user_id
+      AND b.url =
+        'https://hiringcafe.com/' || substring(a.url FROM length('https://www.hiringcafe.com/') + 1)
+  );

--- a/apps/api/src/modules/application/application.service.ts
+++ b/apps/api/src/modules/application/application.service.ts
@@ -10,11 +10,7 @@ import { type PaginationQuery, pageSlice, paginate } from "@jobpilot/contracts/p
 import { singleton } from "tsyringe";
 import { findOwned } from "@/common/errors";
 import { type Prisma, PrismaClient } from "@/generated/prisma/client";
-import {
-  APPLIED_DUPLICATE_THRESHOLD,
-  APPLIED_DUPLICATE_WINDOW_DAYS,
-  findFuzzyDuplicate,
-} from "@/modules/scoring/applied-duplicates";
+import { findAppliedDuplicate } from "./duplicate";
 import { statusChangeOps } from "./status-change";
 
 export interface AppliedListFilters {
@@ -180,79 +176,10 @@ export class ApplicationService {
   }
 
   async check(userId: string, query: AppliedCheckQuery) {
-    const targetUrl = query.url;
-    const title = query.title;
-    const company = query.company;
-
-    if (targetUrl) {
-      const exact = await this.prisma.application.findUnique({
-        where: { userId_url: { userId, url: targetUrl } },
-      });
-      if (exact) {
-        return {
-          applied: true as const,
-          match: {
-            kind: "url" as const,
-            application: {
-              id: exact.id,
-              url: exact.url,
-              title: exact.title,
-              company: exact.company,
-              appliedAt: exact.appliedAt,
-              status: exact.status,
-            },
-          },
-        };
-      }
+    const duplicate = await findAppliedDuplicate(this.prisma, userId, query);
+    if (!duplicate) {
+      return { applied: false as const, match: null };
     }
-
-    if (title && company) {
-      const cutoff = new Date(Date.now() - APPLIED_DUPLICATE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
-      const candidates = await this.prisma.application.findMany({
-        where: { userId, appliedAt: { gte: cutoff } },
-        select: {
-          id: true,
-          url: true,
-          title: true,
-          company: true,
-          appliedAt: true,
-          status: true,
-        },
-        take: 1000,
-      });
-
-      const fuzzy = findFuzzyDuplicate(
-        { title, company },
-        candidates.map((c) => ({
-          id: c.id,
-          url: c.url,
-          title: c.title,
-          company: c.company,
-          appliedAt: c.appliedAt,
-        })),
-        APPLIED_DUPLICATE_THRESHOLD,
-      );
-
-      if (fuzzy) {
-        const matched = candidates.find((c) => c.id === fuzzy.candidate.id)!;
-        return {
-          applied: true as const,
-          match: {
-            kind: "fuzzy" as const,
-            score: fuzzy.score,
-            application: {
-              id: matched.id,
-              url: matched.url,
-              title: matched.title,
-              company: matched.company,
-              appliedAt: matched.appliedAt,
-              status: matched.status,
-            },
-          },
-        };
-      }
-    }
-
-    return { applied: false as const, match: null };
+    return { applied: true as const, match: duplicate };
   }
 }

--- a/apps/api/src/modules/application/duplicate.ts
+++ b/apps/api/src/modules/application/duplicate.ts
@@ -5,6 +5,7 @@ import {
   APPLIED_DUPLICATE_WINDOW_DAYS,
   findFuzzyDuplicate,
 } from "@/modules/scoring/applied-duplicates";
+import { canonicalizeJobUrl } from "./job-url";
 
 /** Enough candidates to cover a heavy month; the fuzzy scan is in-process, so it stays bounded. */
 const MAX_FUZZY_CANDIDATES = 1000;
@@ -51,7 +52,7 @@ export async function findAppliedDuplicate(
 ): Promise<AppliedDuplicate | null> {
   if (lookup.url) {
     const exact = await db.application.findUnique({
-      where: { userId_url: { userId, url: lookup.url } },
+      where: { userId_url: { userId, url: canonicalizeJobUrl(lookup.url) } },
       select: MATCH_SELECT,
     });
     if (exact) {

--- a/apps/api/src/modules/application/duplicate.ts
+++ b/apps/api/src/modules/application/duplicate.ts
@@ -1,0 +1,102 @@
+import type { ApplicationStatus } from "@jobpilot/contracts/application";
+import type { Prisma } from "@/generated/prisma/client";
+import {
+  APPLIED_DUPLICATE_THRESHOLD,
+  APPLIED_DUPLICATE_WINDOW_DAYS,
+  findFuzzyDuplicate,
+} from "@/modules/scoring/applied-duplicates";
+
+/** Enough candidates to cover a heavy month; the fuzzy scan is in-process, so it stays bounded. */
+const MAX_FUZZY_CANDIDATES = 1000;
+
+const MATCH_SELECT = {
+  id: true,
+  url: true,
+  title: true,
+  company: true,
+  appliedAt: true,
+  status: true,
+} as const;
+
+export type DuplicateReader = Pick<Prisma.TransactionClient, "application">;
+
+export interface DuplicateLookup {
+  url?: string;
+  title?: string;
+  company?: string;
+}
+
+export interface DuplicateApplication {
+  id: string;
+  url: string;
+  title: string;
+  company: string;
+  appliedAt: Date;
+  status: ApplicationStatus;
+}
+
+export type AppliedDuplicate =
+  | { kind: "url"; application: DuplicateApplication }
+  | { kind: "fuzzy"; score: number; application: DuplicateApplication };
+
+/**
+ * The one duplicate rule: exact URL, else a fuzzy title+company match inside the rolling window.
+ * Shared by the advisory `/applied/check` endpoint and the server-side guard that blocks a second
+ * apply, so the answer the agent is given and the answer that is enforced cannot drift apart.
+ */
+export async function findAppliedDuplicate(
+  db: DuplicateReader,
+  userId: string,
+  lookup: DuplicateLookup,
+): Promise<AppliedDuplicate | null> {
+  if (lookup.url) {
+    const exact = await db.application.findUnique({
+      where: { userId_url: { userId, url: lookup.url } },
+      select: MATCH_SELECT,
+    });
+    if (exact) {
+      return { kind: "url", application: toDuplicateApplication(exact) };
+    }
+  }
+
+  if (!lookup.title || !lookup.company) {
+    return null;
+  }
+
+  const cutoff = new Date(Date.now() - APPLIED_DUPLICATE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const candidates = await db.application.findMany({
+    where: { userId, appliedAt: { gte: cutoff } },
+    select: MATCH_SELECT,
+    take: MAX_FUZZY_CANDIDATES,
+  });
+
+  const fuzzy = findFuzzyDuplicate(
+    { title: lookup.title, company: lookup.company },
+    candidates,
+    APPLIED_DUPLICATE_THRESHOLD,
+  );
+  if (!fuzzy) {
+    return null;
+  }
+
+  const matched = candidates.find((c) => c.id === fuzzy.candidate.id);
+  return matched
+    ? { kind: "fuzzy", score: fuzzy.score, application: toDuplicateApplication(matched) }
+    : null;
+}
+
+/** The skip reason the apply skills already write, so blocked and self-skipped rows read alike. */
+export function duplicateSkipReason(duplicate: AppliedDuplicate): string {
+  return `Already applied (${duplicate.kind})`;
+}
+
+function toDuplicateApplication(row: {
+  id: string;
+  url: string;
+  title: string;
+  company: string;
+  appliedAt: Date;
+  status: string;
+}): DuplicateApplication {
+  return { ...row, status: row.status as ApplicationStatus };
+}

--- a/apps/api/src/modules/application/job-url.test.ts
+++ b/apps/api/src/modules/application/job-url.test.ts
@@ -1,0 +1,35 @@
+import { canonicalizeJobUrl } from "./job-url";
+import { describe, expect, it } from "bun:test";
+
+describe("canonicalizeJobUrl", () => {
+  // The real pair: same job id slug, two hosts, two applications sent.
+  it("folds hiring.cafe onto hiringcafe.com, path untouched", () => {
+    expect(
+      canonicalizeJobUrl(
+        "https://hiring.cafe/job/director-of-engineering-trading-alpaca-united-states-38fjvmoguw6zvq7r",
+      ),
+    ).toBe(
+      "https://hiringcafe.com/job/director-of-engineering-trading-alpaca-united-states-38fjvmoguw6zvq7r",
+    );
+  });
+
+  it("folds the www variant", () => {
+    expect(canonicalizeJobUrl("https://www.hiringcafe.com/job/abc")).toBe(
+      "https://hiringcafe.com/job/abc",
+    );
+  });
+
+  it("leaves an already-canonical url byte-identical", () => {
+    const url = "https://hiringcafe.com/job/abc";
+    expect(canonicalizeJobUrl(url)).toBe(url);
+  });
+
+  it("leaves other boards alone", () => {
+    const url = "https://www.indeed.com/viewjob?jk=123";
+    expect(canonicalizeJobUrl(url)).toBe(url);
+  });
+
+  it("returns an unparseable value untouched rather than throwing", () => {
+    expect(canonicalizeJobUrl("not a url")).toBe("not a url");
+  });
+});

--- a/apps/api/src/modules/application/job-url.ts
+++ b/apps/api/src/modules/application/job-url.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical form of a job posting URL, so `@@unique([userId, url])` sees one posting as one row.
+ *
+ * hiring.cafe began serving the same postings from hiringcafe.com mid-2026 with byte-identical
+ * paths - the same job id slug under a second host. Two real applications went out to GitLab and
+ * Alpaca because the exact-url check saw two different URLs for one posting.
+ */
+const HOST_ALIASES: Record<string, string> = {
+  "hiring.cafe": "hiringcafe.com",
+  "www.hiringcafe.com": "hiringcafe.com",
+};
+
+/** Rewrites known alias hosts; anything unparseable is returned untouched. */
+export function canonicalizeJobUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  const canonical = HOST_ALIASES[parsed.host.toLowerCase()];
+  if (!canonical) {
+    return url;
+  }
+
+  parsed.host = canonical;
+  return parsed.toString();
+}

--- a/apps/api/src/modules/campaign/jobs/applied-guard.test.ts
+++ b/apps/api/src/modules/campaign/jobs/applied-guard.test.ts
@@ -1,0 +1,106 @@
+// The server-side half of duplicate protection. `/applied/check` is advice the agent can skip;
+// this is the gate a second application actually has to get past, so it is tested on its own.
+import type { DuplicateReader } from "@/modules/application/duplicate";
+import { assertNotAlreadyApplied } from "./applied-guard";
+import { describe, expect, it } from "bun:test";
+
+const APPLIED_AT = new Date("2026-07-20T12:00:00.000Z");
+
+interface FakeApplication {
+  id: string;
+  url: string;
+  title: string;
+  company: string;
+  appliedAt: Date;
+  status: string;
+}
+
+function reader(rows: FakeApplication[]): { db: DuplicateReader; queries: number } {
+  const state = { queries: 0 };
+  const db = {
+    application: {
+      findUnique: async ({ where }: { where: { userId_url: { url: string } } }) => {
+        state.queries += 1;
+        return rows.find((r) => r.url === where.userId_url.url) ?? null;
+      },
+      findMany: async () => {
+        state.queries += 1;
+        return rows;
+      },
+    },
+  };
+  return {
+    db: db as unknown as DuplicateReader,
+    get queries() {
+      return state.queries;
+    },
+  };
+}
+
+const EXISTING: FakeApplication = {
+  id: "app-1",
+  url: "https://example.test/jobs/1",
+  title: "Frontend Engineer",
+  company: "Acme",
+  appliedAt: APPLIED_AT,
+  status: "applied",
+};
+
+describe("assertNotAlreadyApplied", () => {
+  it("blocks the same posting by exact url", async () => {
+    const { db } = reader([EXISTING]);
+
+    await expect(
+      assertNotAlreadyApplied(db, "u1", {
+        url: EXISTING.url,
+        title: "Frontend Engineer",
+        company: "Acme",
+      }),
+    ).rejects.toThrow(/Already applied \(url\)/);
+  });
+
+  // The case the url constraint cannot catch: one posting reposted under a second link.
+  it("blocks the same job listed at a different url", async () => {
+    const { db } = reader([EXISTING]);
+
+    await expect(
+      assertNotAlreadyApplied(db, "u1", {
+        url: "https://other-board.test/postings/999",
+        title: "Senior Frontend Engineer",
+        company: "Acme Inc",
+      }),
+    ).rejects.toThrow(/Already applied \(fuzzy\)/);
+  });
+
+  it("names the clashing application so the skip reason can be written from the error", async () => {
+    const { db } = reader([EXISTING]);
+
+    await expect(
+      assertNotAlreadyApplied(db, "u1", { url: EXISTING.url, title: "x", company: "y" }),
+    ).rejects.toThrow(/"Frontend Engineer" at Acme on 2026-07-20/);
+  });
+
+  it("lets an unrelated job through", async () => {
+    const { db } = reader([EXISTING]);
+
+    await expect(
+      assertNotAlreadyApplied(db, "u1", {
+        url: "https://example.test/jobs/2",
+        title: "Data Scientist",
+        company: "Globex",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("lets a different role at the same employer through", async () => {
+    const { db } = reader([EXISTING]);
+
+    await expect(
+      assertNotAlreadyApplied(db, "u1", {
+        url: "https://example.test/jobs/3",
+        title: "Warehouse Associate",
+        company: "Acme",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/campaign/jobs/applied-guard.ts
+++ b/apps/api/src/modules/campaign/jobs/applied-guard.ts
@@ -1,0 +1,42 @@
+import { conflict } from "@/common/errors";
+import {
+  type DuplicateReader,
+  duplicateSkipReason,
+  findAppliedDuplicate,
+} from "@/modules/application/duplicate";
+
+/** The job fields the duplicate rule reads. */
+interface GuardedJob {
+  url: string;
+  title: string;
+  company: string;
+}
+
+/**
+ * Refuses to move a job into `applying` when this profile already applied to it.
+ *
+ * The apply skills are told to call `/applied/check` first, but that is advice a model can skip,
+ * and a duplicate reaching the browser means a second real application lands in an employer's
+ * inbox - the `@@unique([userId, url])` row guard only dedupes the record, after the fact. Both
+ * routes into `applying` (the pilot claim and the campaign PATCH) run this, so the block does not
+ * depend on which flow is driving.
+ */
+export async function assertNotAlreadyApplied(
+  db: DuplicateReader,
+  userId: string,
+  job: GuardedJob,
+): Promise<void> {
+  const duplicate = await findAppliedDuplicate(db, userId, {
+    url: job.url,
+    title: job.title,
+    company: job.company,
+  });
+  if (!duplicate) {
+    return;
+  }
+
+  // Carries the reason verbatim so the caller can write the skip without restating the rule.
+  throw conflict(
+    `${duplicateSkipReason(duplicate)}: this profile applied to "${duplicate.application.title}" at ${duplicate.application.company} on ${duplicate.application.appliedAt.toISOString().slice(0, 10)}. Record the job as skipped with this reason instead of applying again.`,
+  );
+}

--- a/apps/api/src/modules/campaign/jobs/job-result.ts
+++ b/apps/api/src/modules/campaign/jobs/job-result.ts
@@ -2,6 +2,7 @@ import type { CampaignJobResultInput, CampaignJobStatus } from "@jobpilot/contra
 import { CAMPAIGN_JOB_TERMINAL_OUTCOMES } from "@jobpilot/contracts/campaign";
 import { conflict, findOwned } from "@/common/errors";
 import type { PrismaClient } from "@/generated/prisma/client";
+import { canonicalizeJobUrl } from "@/modules/application/job-url";
 import { normalizeCompanyName, normalizeJobTitle } from "@/modules/scoring/applied-duplicates";
 import { toWireCampaignSource } from "../campaign.mapper";
 import { deriveCampaignSummary } from "../campaign.summary";
@@ -40,7 +41,7 @@ export async function writeJobResult(
     const application =
       data.outcome === "applied"
         ? await prisma.application.findUnique({
-            where: { userId_url: { userId, url: existing.url } },
+            where: { userId_url: { userId, url: canonicalizeJobUrl(existing.url) } },
           })
         : null;
     return {
@@ -75,11 +76,11 @@ export async function writeJobResult(
     const application =
       data.outcome === "applied"
         ? await tx.application.upsert({
-            where: { userId_url: { userId, url: job.url } },
+            where: { userId_url: { userId, url: canonicalizeJobUrl(job.url) } },
             update: {},
             create: {
               userId,
-              url: job.url,
+              url: canonicalizeJobUrl(job.url),
               title: job.title,
               company: job.company,
               location: job.location,

--- a/apps/api/src/modules/campaign/jobs/job.service.test.ts
+++ b/apps/api/src/modules/campaign/jobs/job.service.test.ts
@@ -62,6 +62,7 @@ function setup() {
     },
     application: {
       findUnique: async () => application,
+      findMany: async () => (application ? [application] : []),
       upsert: async ({ create }: { create: Record<string, unknown> }) => {
         applicationUpserts += 1;
         application = { id: "app1", ...create };
@@ -91,6 +92,9 @@ function setup() {
     variantLinks,
     setStatus(status: string) {
       job = { ...job, status };
+    },
+    setApplication(row: Record<string, unknown>) {
+      application = row;
     },
   };
 }
@@ -222,5 +226,49 @@ describe("CampaignJobService queued rows", () => {
     await expect(state.service.patchJob("u1", "c1", "j1", { status: "approved" })).rejects.toThrow(
       "cannot transition from queued to approved",
     );
+  });
+});
+
+// Both routes into `applying` have to refuse a job this profile already applied to - the agent's
+// own `/applied/check` call is advice it can skip, and by the browser step it is already too late.
+describe("CampaignJobService duplicate apply guard", () => {
+  const EXISTING = {
+    id: "app-1",
+    url: "https://example.test/jobs/1",
+    title: "Engineer",
+    company: "Acme",
+    appliedAt: new Date(APPLIED_AT),
+    status: "applied",
+  };
+
+  it("blocks the campaign PATCH into applying", async () => {
+    const state = setup();
+    state.setStatus("approved");
+    state.setApplication(EXISTING);
+
+    await expect(state.service.patchJob("u1", "c1", "j1", { status: "applying" })).rejects.toThrow(
+      /Already applied/,
+    );
+    expect(state.job.status).toBe("approved");
+  });
+
+  it("blocks the pilot claim", async () => {
+    const state = setup();
+    state.setStatus("approved");
+    state.setApplication(EXISTING);
+
+    await expect(state.service.claimJobForApply("u1", "c1", "j1")).rejects.toThrow(
+      /Already applied/,
+    );
+    expect(state.job.status).toBe("approved");
+  });
+
+  it("still lets a job through when nothing matches", async () => {
+    const state = setup();
+    state.setStatus("approved");
+
+    const patched = await state.service.patchJob("u1", "c1", "j1", { status: "applying" });
+
+    expect(patched).toMatchObject({ status: "applying" });
   });
 });

--- a/apps/api/src/modules/campaign/jobs/job.service.ts
+++ b/apps/api/src/modules/campaign/jobs/job.service.ts
@@ -23,6 +23,7 @@ import { JobListingPublisher } from "@/modules/job-listing";
 import { PROMOTABLE_SOURCES } from "../campaign.mapper";
 import { deriveCampaignSummary } from "../campaign.summary";
 import { ensureCampaignOwned } from "../campaign.utils";
+import { assertNotAlreadyApplied } from "./applied-guard";
 import { writeJobRescan, writeJobRetry } from "./job-commands";
 import { isTerminalJob, writeJobResult } from "./job-result";
 
@@ -38,7 +39,7 @@ const ALLOWED_TRANSITIONS: Record<CampaignJobStatus, readonly CampaignJobStatus[
   skipped: [],
 };
 
-type JobTransaction = Pick<Prisma.TransactionClient, "job">;
+type JobTransaction = Pick<Prisma.TransactionClient, "job" | "application">;
 
 interface ScoredJobPromotion {
   key: string;
@@ -161,6 +162,9 @@ export class CampaignJobService {
 
     const job = await this.prisma.$transaction(async (tx) => {
       if (patch.status && patch.status !== existing.status) {
+        if (patch.status === "applying") {
+          await assertNotAlreadyApplied(tx, userId, existing);
+        }
         const changed = await tx.job.updateMany({
           where: { campaignId, key, status: existing.status },
           data: {
@@ -225,6 +229,13 @@ export class CampaignJobService {
     campaignId: string,
     key: string,
   ): Promise<Job> {
+    const target = await tx.job.findFirst({
+      where: { campaignId, key, status: "approved", campaign: { userId } },
+      select: { url: true, title: true, company: true },
+    });
+    if (!target) throw conflict("Job is no longer approved.");
+    await assertNotAlreadyApplied(tx, userId, target);
+
     const claim = await tx.job.updateMany({
       where: { campaignId, key, status: "approved", campaign: { userId } },
       data: { status: "applying" },

--- a/apps/api/src/modules/scoring/applied-duplicates.test.ts
+++ b/apps/api/src/modules/scoring/applied-duplicates.test.ts
@@ -1,0 +1,101 @@
+// Fixtures are the seven pairs the 30-day rule actually flagged across 105 real applications.
+// Four were genuine repeat applications; three were distinct employers sharing a generic title,
+// and those three are what the employer bar exists to keep out.
+import { APPLIED_DUPLICATE_THRESHOLD, findFuzzyDuplicate } from "./applied-duplicates";
+import { describe, expect, it } from "bun:test";
+
+function candidate(title: string, company: string) {
+  return [
+    {
+      id: "prior",
+      url: "https://hiringcafe.com/job/prior",
+      title,
+      company,
+      appliedAt: new Date("2026-08-05T12:00:00Z"),
+    },
+  ];
+}
+
+function match(title: string, company: string, priorTitle: string, priorCompany: string) {
+  return findFuzzyDuplicate(
+    { title, company },
+    candidate(priorTitle, priorCompany),
+    APPLIED_DUPLICATE_THRESHOLD,
+  );
+}
+
+describe("findFuzzyDuplicate - repeat applications it must catch", () => {
+  it("catches the identical posting relisted under a second host", () => {
+    expect(
+      match(
+        "Director of Engineering, Trading",
+        "Alpaca",
+        "Director of Engineering, Trading",
+        "Alpaca",
+      ),
+    ).toMatchObject({ score: 100 });
+  });
+
+  it("catches the same role spelled out instead of abbreviated", () => {
+    expect(
+      match(
+        "(Remote) Vice President of Research & Development",
+        "Harris Computer",
+        "(Remote) VP of R&D",
+        "Harris Computer",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("catches an employer whose scraped name has page text glued on", () => {
+    // The row really was stored as "AbbVieNew York Stock Exchange"; similarity alone gives 84.
+    expect(
+      match(
+        "Executive Director, Engineering - Allergan Aesthetics",
+        "AbbVie",
+        "Executive Director, Engineering - Allergan Aesthetics",
+        "AbbVieNew York Stock Exchange",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("still catches a seniority-only title difference at one employer", () => {
+    expect(
+      match("Senior Frontend Engineer", "Acme Inc", "Frontend Engineer", "Acme"),
+    ).not.toBeNull();
+  });
+});
+
+describe("findFuzzyDuplicate - distinct employers it must not block", () => {
+  it("does not match Clarity against Cardiff on a shared generic title", () => {
+    expect(
+      match("Director of Engineering", "Cardiff", "Director of Engineering", "Clarity"),
+    ).toBeNull();
+  });
+
+  it("does not match Robots & Pencils against Robust Open Online Safety Tools", () => {
+    expect(
+      match(
+        "Director of Engineering",
+        "Robots & Pencils",
+        "Director of Engineering",
+        "Robust Open Online Safety Tools",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not match Orbital Engineering against Imagine Learning", () => {
+    expect(
+      match(
+        "Director of Software Engineering",
+        "Orbital Engineering",
+        "Director of Software Engineering",
+        "Imagine Learning",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not match a different role at the same employer", () => {
+    expect(match("Warehouse Associate", "Acme", "Frontend Engineer", "Acme")).toBeNull();
+  });
+});

--- a/apps/api/src/modules/scoring/applied-duplicates.ts
+++ b/apps/api/src/modules/scoring/applied-duplicates.ts
@@ -70,6 +70,18 @@ export function normalizeCompanyName(company: string): string {
 export const APPLIED_DUPLICATE_THRESHOLD = 90;
 export const APPLIED_DUPLICATE_WINDOW_DAYS = 30;
 
+/**
+ * A match must clear the employer bar on its own. The blended score alone lets an identical but
+ * generic title ("Director of Engineering", worth 60 of the 100) carry a pair over the line on
+ * weak employer similarity - real data had Clarity/Cardiff at 74 and Imagine Learning/Orbital
+ * Engineering at 76 scoring 90, i.e. two different companies read as one job.
+ */
+export const APPLIED_DUPLICATE_COMPANY_THRESHOLD = 90;
+export const APPLIED_DUPLICATE_TITLE_THRESHOLD = 85;
+
+/** Long enough that a prefix is the employer, not a coincidence. */
+const MIN_EMPLOYER_PREFIX = 5;
+
 function jaro(a: string, b: string): number {
   if (a === b) {
     return 1;
@@ -175,9 +187,26 @@ export interface FuzzyMatchResult {
 }
 
 /**
+ * Whether two normalized employer names are the same company.
+ *
+ * The prefix arm covers scraped names that arrive with page text glued on - a real row stored
+ * "AbbVieNew York Stock Exchange" for AbbVie, which similarity alone scores 84.
+ */
+function isSameEmployer(a: string, b: string, similarity: number): boolean {
+  if (similarity >= APPLIED_DUPLICATE_COMPANY_THRESHOLD) {
+    return true;
+  }
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  return shorter.length >= MIN_EMPLOYER_PREFIX && longer.startsWith(shorter);
+}
+
+/**
  * Pick the best fuzzy match within a candidate set using the normalized
  * title + company comparison. Caller is responsible for restricting
  * candidates to the 30-day window and tenant scope.
+ *
+ * Employer and title each clear their own bar before the blended score is consulted, so this
+ * only ever matches a subset of what the blended score alone would have matched.
  */
 export function findFuzzyDuplicate(
   input: FuzzyMatchInput,
@@ -201,10 +230,17 @@ export function findFuzzyDuplicate(
       continue;
     }
 
-    const titleScore = calculateSimilarity(normTitle, cTitle);
     const companyScore = calculateSimilarity(normCompany, cCompany);
-    const score = Math.round(titleScore * 0.6 + companyScore * 0.4);
+    if (!isSameEmployer(normCompany, cCompany, companyScore)) {
+      continue;
+    }
 
+    const titleScore = calculateSimilarity(normTitle, cTitle);
+    if (titleScore < APPLIED_DUPLICATE_TITLE_THRESHOLD) {
+      continue;
+    }
+
+    const score = Math.round(titleScore * 0.6 + companyScore * 0.4);
     if (score >= threshold && (!best || score > best.score)) {
       best = { candidate, score };
     }

--- a/plugin/skills/_shared/campaign-flow.md
+++ b/plugin/skills/_shared/campaign-flow.md
@@ -19,6 +19,11 @@ Exact URL match plus fuzzy title+company over a 30-day window; `.match.kind` is 
 and move on without opening a tab. Skills that deviate (e.g. `networking` keeps applied jobs and
 records `.match.application.id` as `relatedAppId`) say so inline.
 
+The server enforces the same rule independently: moving a job into `applying` - the `PATCH`
+below or the pilot's claim - 409s when it duplicates an application, with a message opening
+`Already applied (<kind>)`. That is the dedupe verdict, not a transient failure. Write the
+job's `skipped` result with that reason and move on; never retry the transition.
+
 ## Terminal result writes
 
 Non-terminal transitions go through `PATCH /api/campaigns/$CID/jobs/<key>`


### PR DESCRIPTION
Fixes #24.

`GET /api/applied/check` is advisory - the apply skills are told to call it and skip, but nothing enforced it. A model that skips the step, or a posting that reappears under a second URL, reached the browser and submitted again. The `@@unique([userId, url])` index and the idempotent `upsert` in `writeJobResult` only dedupe the *record*, and only once the application has already landed with the employer.

### The change

Guard the transition into `applying`, which every application passes through. It has exactly two entry points - the campaign `PATCH` and the pilot claim. The three other writes of that status (agenda expiry ×2, claim abandon) are releases back to `approved`, not entries, so those two cover it.

Two details worth calling out:

- **One rule, one implementation.** The matching logic moved out of `ApplicationService.check` into a shared `findAppliedDuplicate`, with both `/applied/check` and the guard pointing at it - otherwise the answer the agent is *given* and the answer that is *enforced* can drift apart. This also removes the duplicated fuzzy-scan block from the service (`-83` lines there).
- **The 409 opens with `Already applied (<kind>)`**, the exact `skipReason` string the skills already write, so the agent can record the skip straight from the error. `_shared/campaign-flow.md` now says the 409 is the dedupe verdict, not a transient failure to retry.

### Tests

Five unit tests on the guard, three on the wiring (campaign PATCH blocked, pilot claim blocked, clean job still passes). Mutation-checked: disabling the guard fails exactly five, while both negative cases - an unrelated job, and a *different role at the same employer* - keep passing, so the fuzzy rule is not over-blocking.

512 API + 7 contracts tests, both typechecks, Biome clean.

### Deliberate non-goal

`writeJobResult` still accepts an `applied` result without a prior `applying`, which bypasses the guard. Left alone on purpose: at that point the submission has already happened, and refusing the write would discard the record of a real application - worse than the duplicate it would prevent. Every documented flow transitions through `applying`. Happy to make the state machine strict instead if you'd prefer.

Unchanged: the 30-day fuzzy window (exact-URL matching stays unbounded), and applications made outside JobPilot, which are unknowable.
