### PR TITLE
docs: stop asserting that localhost:5433 is the SSH tunnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,10 @@ Auth: on terminal start the web fetches the user's reusable terminal token
 Root (`bun run …`):
 
 - `dev` - terminal + api + web together; `dev:api` / `dev:web` / `dev:terminal` run one.
-- `db:tunnel` - SSH tunnel to the remote PostgreSQL. No local DB container; `DATABASE_URL`
-  points at the tunnel's local port (5433).
+- `db:tunnel` - SSH tunnel to the remote PostgreSQL, bound to `localhost:5433`. The repo ships no
+  database container, so `DATABASE_URL` points at whichever PostgreSQL you supplied - a local one
+  you run yourself or the tunnel. Both conventionally use 5433, so check what is actually on that
+  port (`docker ps`, `lsof -i :5433`) before concluding which you are talking to.
 - `db:setup` - Prisma generate + apply migrations + seed.
 - `test` - the API suite plus the contracts suite (`bun test` in `apps/api` and
   `packages/contracts`).

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,7 +2,8 @@
 NODE_ENV=development
 PORT=4101
 
-# Postgres - the SSH tunnel's local port (5433 avoids a local PG service on 5432); see db:tunnel
+# Postgres - whichever one you supplied: a local instance you run yourself, or the SSH tunnel
+# below (see db:tunnel). Both conventionally bind 5433, leaving 5432 to a local PG service.
 DATABASE_URL=postgresql://jobpilot:jobpilot@localhost:5433/jobpilot
 
 # Remote DB via SSH tunnel


### PR DESCRIPTION
Both `CLAUDE.md` and `apps/api/.env.example` described `localhost:5433` as the SSH tunnel's port as settled fact.

The "no local DB container" half is true - the repo ships none - but a self-run local PostgreSQL is an equally supported setup, which `docs/development.md` already says ("either one you run yourself or the remote database through the SSH tunnel"). It conventionally binds the same 5433, since 5432 is left to a local PG service.

Reading the old wording as authoritative sent me looking for a remote database while the data was sitting in a local instance on that port. This keeps the true claim, drops the false certainty, and names the two commands that settle which one is actually listening.

No behavior change - comments and docs only.
