### PR TITLE
fix(pilot): cap claim lifetime even while heartbeats continue

### DIFF
--- a/apps/api/src/modules/pilot/agenda/claim.service.test.ts
+++ b/apps/api/src/modules/pilot/agenda/claim.service.test.ts
@@ -119,3 +119,65 @@ describe("ClaimService snapshots", () => {
     expect(creates).toHaveLength(0);
   });
 });
+
+const USER_ID = "5f0d4d0e-4f27-4a0a-9f4e-2b1c6f1f7f01";
+const CLAIM_ID = "4c965efd-b586-49ea-825b-1af715760116";
+
+/** Minimal harness for the heartbeat path, which the snapshot fake above does not reach. */
+function heartbeatDb(grantedAt: Date) {
+  const writes: Record<string, unknown>[] = [];
+  const db = {
+    pilotClaim: {
+      findFirst: async () => ({ grantedAt }),
+      updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+        writes.push(data);
+        return { count: 1 };
+      },
+      findUniqueOrThrow: async () => ({
+        id: CLAIM_ID,
+        userId: USER_ID,
+        kind: "job.apply",
+        subjectType: "job",
+        subjectId: "j1",
+        payload: snapshot.items[0].payload,
+        grantedAt,
+        heartbeatAt: new Date(),
+        expiresAt: new Date(),
+        releasedAt: null,
+        outcome: null,
+      }),
+    },
+  };
+  const campaignJobs = {} as unknown as CampaignJobService;
+  return {
+    service: new ClaimService(db as unknown as PrismaClient, campaignJobs),
+    get expiry() {
+      return writes[0]?.expiresAt as Date;
+    },
+  };
+}
+
+describe("ClaimService heartbeat lifetime ceiling", () => {
+  it("extends a young claim by the usual TTL", async () => {
+    const state = heartbeatDb(new Date(Date.now() - 60_000));
+    await state.service.heartbeat(USER_ID, CLAIM_ID);
+    const minutesOut = (state.expiry.getTime() - Date.now()) / 60_000;
+    expect(minutesOut).toBeGreaterThan(14);
+    expect(minutesOut).toBeLessThanOrEqual(15);
+  });
+
+  it("holds a long-running claim to the ceiling instead of sliding it forward again", async () => {
+    // Granted 20 minutes ago: the ceiling leaves 5, where the TTL alone would hand back 15.
+    const state = heartbeatDb(new Date(Date.now() - 20 * 60_000));
+    await state.service.heartbeat(USER_ID, CLAIM_ID);
+    const minutesOut = (state.expiry.getTime() - Date.now()) / 60_000;
+    expect(minutesOut).toBeGreaterThan(4);
+    expect(minutesOut).toBeLessThanOrEqual(5);
+  });
+
+  it("stops extending a claim already past the ceiling, so the sweep can reclaim it", async () => {
+    const state = heartbeatDb(new Date(Date.now() - 90 * 60_000));
+    await state.service.heartbeat(USER_ID, CLAIM_ID);
+    expect(state.expiry.getTime()).toBeLessThan(Date.now());
+  });
+});

--- a/apps/api/src/modules/pilot/agenda/claim.service.ts
+++ b/apps/api/src/modules/pilot/agenda/claim.service.ts
@@ -7,11 +7,23 @@ import { type Job, type PilotClaim, type Prisma, PrismaClient } from "@/generate
 import { AlreadyAppliedError } from "@/modules/campaign/jobs/applied-guard";
 import { CampaignJobService } from "@/modules/campaign/jobs/job.service";
 import { toPilotClaim } from "../pilot.mapper";
+import { MAX_CLAIM_LIFETIME_MS } from "./constants";
 import { verifyGrant } from "./grant";
 import { parseJobPayload } from "./job-mutations";
 import { parseAgendaSnapshot } from "./service";
 
 const CLAIM_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Holds a heartbeat-extended expiry to a fixed ceiling from when the claim was granted, so a
+ * stuck-but-beating driver still expires no matter which kind of work it is running.
+ */
+function lifetimeCap(claim: { grantedAt: Date } | null, proposedExpiry: number): number {
+  if (!claim) {
+    return proposedExpiry;
+  }
+  return Math.min(proposedExpiry, claim.grantedAt.getTime() + MAX_CLAIM_LIFETIME_MS);
+}
 
 /** Either the claim, or the duplicate refusal the guard recorded a skip for. */
 type ClaimResult =
@@ -121,9 +133,18 @@ export class ClaimService {
   }
 
   async heartbeat(userId: string, id: string) {
+    const open = await this.prisma.pilotClaim.findFirst({
+      where: { id, userId, releasedAt: null },
+      select: { grantedAt: true },
+    });
+
+    const now = Date.now();
     const updated = await this.prisma.pilotClaim.updateMany({
       where: { id, userId, releasedAt: null },
-      data: { heartbeatAt: new Date(), expiresAt: new Date(Date.now() + CLAIM_TTL_MS) },
+      data: {
+        heartbeatAt: new Date(now),
+        expiresAt: new Date(lifetimeCap(open, now + CLAIM_TTL_MS)),
+      },
     });
     if (updated.count === 0) {
       const existing = await this.prisma.pilotClaim.findFirst({ where: { id, userId } });

--- a/apps/api/src/modules/pilot/agenda/constants.ts
+++ b/apps/api/src/modules/pilot/agenda/constants.ts
@@ -101,6 +101,22 @@ export const STALE_APPLYING_MS = 30 * 60 * 1000;
  */
 export const APPROVED_JOB_STALE_MS = 7 * DAY_MS;
 
+/**
+ * Ceiling on how long any claim may be held, heartbeats included.
+ *
+ * A heartbeat slides `expiresAt` forward, so a driver that is stuck but still beating never
+ * expires. Two kinds showed it in real data: 26 apply claims averaged 43 minutes (one ran 18.6
+ * hours with no application to show for it), and 4 `question.answered` claims were held 24.5 hours
+ * - work that normally finishes in under 13 minutes, since the human has already answered by the
+ * time it is queued.
+ *
+ * No kind of work has ever legitimately run past this: the slowest success of any kind was an
+ * apply at 22.0 min (p99 18.7), then discovery at 15.9 and questions at 12.6. The margin is thin
+ * enough that a healthy apply can be cut off here, so the cost is real - that attempt is released
+ * rather than retried.
+ */
+export const MAX_CLAIM_LIFETIME_MS = 25 * 60 * 1000;
+
 /** Each open apply claim becomes a NOT clause in the stale sweep; the pilot never holds many at once. */
 export const MAX_OPEN_APPLY_CLAIMS = 20;
 


### PR DESCRIPTION
## The problem

`heartbeat()` sets `expiresAt` to `now + CLAIM_TTL_MS` on every beat. A driver that is stuck but still beating therefore never expires, the stale sweep never reclaims its job, and the job sits in `applying` indefinitely.

Two kinds showed this in my own instance's data:

- **26 apply claims averaged 43 minutes**, one running **18.6 hours** with no `Application` row to show for it.
- **4 `question.answered` claims were held 24.5 hours** — work that normally finishes in under 13 minutes, since the human has already answered by the time it is queued.

## The change

The heartbeat clamps the proposed expiry to a ceiling measured from `grantedAt`, so beating can postpone expiry but never remove it. `MAX_CLAIM_LIFETIME_MS` is 25 minutes.

That number is picked against the observed distribution rather than guessed: the slowest *successful* run of any kind was an apply at 22.0 min (p99 18.7), then discovery at 15.9 and questions at 12.6.

The tradeoff is real and worth stating: the margin is thin enough that a genuinely long, healthy apply can be cut off here. When that happens the attempt is released rather than retried. I judged an unbounded claim — which parks the job silently and forever — to be the worse failure, but the constant is easy to raise if you read it differently.

## Notes

- 3 tests added covering a young claim, one past the ceiling, and one already beyond it.
- `bun --cwd=apps/api run test` passes (572), typecheck and `biome ci` clean.
- No migration, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tQXq4YZHb4FJy6fNwbQS