### PR TITLE
fix(jobs): refuse a claim while a sibling job is applying

### DIFF
--- a/apps/api/src/modules/campaign/jobs/applied-guard.test.ts
+++ b/apps/api/src/modules/campaign/jobs/applied-guard.test.ts
@@ -31,6 +31,8 @@ function transaction(rows: FakeApplication[]): { tx: GuardTransaction; writes: W
         rows.filter((r) => r.appliedAt >= where.appliedAt.gte),
     },
     job: {
+      // The in-flight reservation scan; nothing else is mid-apply in these cases.
+      findMany: async () => [],
       updateManyAndReturn: async (args: Written) => {
         writes.push(args);
         return [{ key: args.where.key, status: "skipped", ...args.data }];

--- a/apps/api/src/modules/campaign/jobs/applied-guard.ts
+++ b/apps/api/src/modules/campaign/jobs/applied-guard.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, HttpError } from "@/common/errors";
+import { conflict, ErrorCodes, HttpError } from "@/common/errors";
 import type { Job, Prisma } from "@/generated/prisma/client";
 import {
   type AppliedDuplicate,
@@ -6,9 +6,12 @@ import {
   duplicateSkipReason,
   findAppliedDuplicate,
 } from "@/modules/application/duplicate";
+import { findInFlightDuplicate, type InFlightReader } from "./in-flight";
 
 /** Wider than a read: the guard writes the skip alongside the duplicate scan. */
-export type GuardTransaction = DuplicateReader & Pick<Prisma.TransactionClient, "job">;
+export type GuardTransaction = DuplicateReader &
+  InFlightReader &
+  Pick<Prisma.TransactionClient, "job">;
 
 interface GuardedJob {
   campaignId: string;
@@ -42,12 +45,22 @@ export class AlreadyAppliedError extends HttpError {
  *
  * The skills' own `/applied/check` is advice a model can skip, and `@@unique([userId, url])` only
  * dedupes the record once the second application has already landed with the employer.
+ *
+ * The in-flight pass runs first and is deliberately *not* recorded as a skip: the other worker may
+ * still fail, and a posting nobody applied to must stay approved.
  */
 export async function skipIfAlreadyApplied(
   tx: GuardTransaction,
   userId: string,
   job: GuardedJob,
 ): Promise<AlreadyAppliedError | null> {
+  const inFlight = await findInFlightDuplicate(tx, userId, job);
+  if (inFlight) {
+    throw conflict(
+      `Already applying: another worker holds "${inFlight.title}" at ${inFlight.company} (${inFlight.campaignId}/${inFlight.key}). Record this job as skipped with reason "Already applied (in-flight)" instead of applying alongside it.`,
+    );
+  }
+
   const duplicate = await findAppliedDuplicate(tx, userId, job);
   if (!duplicate) {
     return null;

--- a/apps/api/src/modules/campaign/jobs/in-flight.test.ts
+++ b/apps/api/src/modules/campaign/jobs/in-flight.test.ts
@@ -1,0 +1,100 @@
+// The window concurrency opens: an `Application` row appears only when a result is written, so
+// between claim and result two workers can both see "not applied" for one posting. An `applying`
+// row is the reservation that closes it. Fixtures are the real GitLab/Alpaca duplicate pair.
+import { findInFlightDuplicate, type InFlightReader } from "./in-flight";
+import { describe, expect, it } from "bun:test";
+
+const GITLAB_LEGACY =
+  "https://hiring.cafe/job/director-of-engineering-growth-and-monetization-gitlab-canada-q05zkngwllkfigpu";
+const GITLAB_CANONICAL =
+  "https://hiringcafe.com/job/director-of-engineering-growth-and-monetization-gitlab-canada-q05zkngwllkfigpu";
+
+/** Honors the NOT clause the real query sends, so self-exclusion is actually exercised. */
+function reader(rows: Array<Record<string, unknown>>): InFlightReader {
+  return {
+    job: {
+      findMany: async ({ where }: { where: { NOT?: { campaignId: string; key: string } } }) =>
+        rows.filter(
+          (row) => !(row.campaignId === where.NOT?.campaignId && row.key === where.NOT?.key),
+        ),
+    },
+  } as unknown as InFlightReader;
+}
+
+const CLAIMING = {
+  campaignId: "c2",
+  key: "j2",
+  url: GITLAB_CANONICAL,
+  title: "Director of Engineering, Growth & Monetization",
+  company: "GitLab",
+};
+
+describe("findInFlightDuplicate", () => {
+  it("blocks the same posting held under the other host", async () => {
+    const db = reader([
+      {
+        campaignId: "c1",
+        key: "j1",
+        url: GITLAB_LEGACY,
+        title: "Director of Engineering, Growth & Monetization",
+        company: "GitLab",
+      },
+    ]);
+
+    expect(await findInFlightDuplicate(db, "u1", CLAIMING)).toMatchObject({ key: "j1" });
+  });
+
+  it("blocks a relisted posting whose title was rephrased", async () => {
+    const db = reader([
+      {
+        campaignId: "c1",
+        key: "j1",
+        url: "https://hiringcafe.com/job/remote-vp-of-r-and-d-harris-computer-florida-xsblxi7zpf3smgu2",
+        title: "(Remote) VP of R&D",
+        company: "Harris Computer",
+      },
+    ]);
+
+    const claiming = {
+      campaignId: "c2",
+      key: "j2",
+      url: "https://hiringcafe.com/job/remote-vice-president-of-research-and-development-harris-computer-y2bgwhpg4bo",
+      title: "(Remote) Vice President of Research & Development",
+      company: "Harris Computer",
+    };
+
+    expect(await findInFlightDuplicate(db, "u1", claiming)).toMatchObject({ key: "j1" });
+  });
+
+  it("ignores the row being claimed itself", async () => {
+    const db = reader([{ ...CLAIMING }]);
+
+    expect(await findInFlightDuplicate(db, "u1", CLAIMING)).toBeNull();
+  });
+
+  it("lets a different employer through while another apply is open", async () => {
+    const db = reader([
+      {
+        campaignId: "c1",
+        key: "j1",
+        url: "https://hiringcafe.com/job/director-of-engineering-clarity",
+        title: "Director of Engineering",
+        company: "Clarity",
+      },
+    ]);
+
+    const claiming = {
+      campaignId: "c2",
+      key: "j2",
+      url: "https://hiringcafe.com/job/director-of-engineering-cardiff",
+      title: "Director of Engineering",
+      company: "Cardiff",
+    };
+
+    expect(await findInFlightDuplicate(db, "u1", claiming)).toBeNull();
+  });
+
+  it("is a no-op when nothing else is being applied to", async () => {
+    expect(await findInFlightDuplicate(reader([]), "u1", CLAIMING)).toBeNull();
+  });
+});

--- a/apps/api/src/modules/campaign/jobs/in-flight.ts
+++ b/apps/api/src/modules/campaign/jobs/in-flight.ts
@@ -1,0 +1,71 @@
+import type { Prisma } from "@/generated/prisma/client";
+import { canonicalizeJobUrl } from "@/modules/application/job-url";
+import {
+  APPLIED_DUPLICATE_THRESHOLD,
+  findFuzzyDuplicate,
+} from "@/modules/scoring/applied-duplicates";
+
+/** Rows already being applied to are the reservation; no separate table is needed. */
+export type InFlightReader = Pick<Prisma.TransactionClient, "job">;
+
+export interface InFlightJob {
+  campaignId: string;
+  key: string;
+  url: string;
+  title: string;
+  company: string;
+}
+
+/** Bounds the scan; a profile never has more than a handful of applies open at once. */
+const MAX_IN_FLIGHT = 100;
+
+/**
+ * A duplicate of this job that another worker is applying to *right now*.
+ *
+ * The applied-duplicate rule only sees `Application` rows, which are written when a result is
+ * recorded - minutes after the claim was granted. Serially that gap is invisible. Run two workers
+ * and it is the whole apply: both claim the same posting under two URLs, both see no application,
+ * and both submit. That is exactly how GitLab and Alpaca were applied to twice. Treating an
+ * `applying` row as a reservation closes the window without a new table.
+ */
+export async function findInFlightDuplicate(
+  db: InFlightReader,
+  userId: string,
+  job: InFlightJob,
+): Promise<InFlightJob | null> {
+  const others = await db.job.findMany({
+    where: {
+      status: "applying",
+      campaign: { userId },
+      NOT: { campaignId: job.campaignId, key: job.key },
+    },
+    take: MAX_IN_FLIGHT,
+    select: { campaignId: true, key: true, url: true, title: true, company: true },
+  });
+  if (others.length === 0) {
+    return null;
+  }
+
+  const canonical = canonicalizeJobUrl(job.url);
+  const sameUrl = others.find((other) => canonicalizeJobUrl(other.url) === canonical);
+  if (sameUrl) {
+    return sameUrl;
+  }
+
+  const fuzzy = findFuzzyDuplicate(
+    { title: job.title, company: job.company },
+    others.map((other) => ({
+      id: `${other.campaignId}:${other.key}`,
+      url: other.url,
+      title: other.title,
+      company: other.company,
+      appliedAt: new Date(),
+    })),
+    APPLIED_DUPLICATE_THRESHOLD,
+  );
+  if (!fuzzy) {
+    return null;
+  }
+
+  return others.find((other) => `${other.campaignId}:${other.key}` === fuzzy.candidate.id) ?? null;
+}

--- a/apps/api/src/modules/campaign/jobs/job.service.test-helpers.ts
+++ b/apps/api/src/modules/campaign/jobs/job.service.test-helpers.ts
@@ -44,6 +44,8 @@ export function setup() {
   const db = {
     job: {
       findFirst: async () => ({ ...job, campaign }),
+      // The in-flight reservation scan; no sibling job is mid-apply in these tests.
+      findMany: async () => [],
       updateMany: async ({
         where,
         data,


### PR DESCRIPTION
## The problem

`findAppliedDuplicate` reads `Application` rows, and one only exists once a result is recorded — minutes after the claim was granted. Inside that window a second worker looking at the same posting under a different URL finds no application, passes the guard, and submits.

This is not hypothetical. On my instance it produced **two applications to GitLab and two to Alpaca**. The url arm missed because the two listings differed by host; the fuzzy arm missed because there was nothing yet to match against.

The window is widest with concurrent workers, but it exists serially too — any claim held while the previous result is still unwritten.

## The change

An `applying` row is already the reservation, so no new table is needed. `skipIfAlreadyApplied` now scans for a sibling job mid-apply that resolves to the same posting (same canonical url, or a fuzzy title+company match at the existing threshold) and refuses before the applied check.

One deliberate asymmetry: unlike the applied-duplicate refusal this does **not** record the job as `skipped`. The other worker may still fail, and a posting nobody actually applied to has to stay `approved` so the retry can pick it up.

## Notes

- Scan is bounded (`MAX_IN_FLIGHT = 100`) and scoped to the user's own campaigns.
- Reuses the existing `canonicalizeJobUrl` and `findFuzzyDuplicate` at `APPLIED_DUPLICATE_THRESHOLD`, so it agrees with the applied rule by construction.
- 2 fake-Prisma test fixtures needed a `job.findMany` stub for the new scan.
- `bun --cwd=apps/api run test` passes (574), typecheck and `biome ci` clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tQXq4YZHb4FJy6fNwbQS