### PR TITLE
feat(web): show a load error in data tables instead of the empty overlay

### DIFF
--- a/apps/web/src/components/features/cover-letters/cover-letters-table.tsx
+++ b/apps/web/src/components/features/cover-letters/cover-letters-table.tsx
@@ -82,6 +82,8 @@ export function CoverLettersTable(): ReactElement {
       rows={rows}
       columns={columns}
       loading={lettersQuery.isLoading}
+      errorTitle={lettersQuery.isError ? "Couldn't load your cover letters." : undefined}
+      onRetry={() => void lettersQuery.refetch()}
       getRowId={(row) => row.id}
       onRowClick={(row) => router.push(`/cover-letters/${row.id}` as Route)}
       {...gridPagination(pagination, lettersQuery.data?.pagination)}

--- a/apps/web/src/components/ui/data/data-table.tsx
+++ b/apps/web/src/components/ui/data/data-table.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { type ReactElement, useMemo } from "react";
+import { type HTMLAttributes, type ReactElement, useMemo } from "react";
+import { Button, Stack, Typography } from "@mui/material";
 import {
   DataGrid,
   type DataGridProps,
   type GridColDef,
   type GridValidRowModel,
+  type NoRowsOverlayPropsOverrides,
 } from "@mui/x-data-grid";
 import { EmptyState } from "./empty-state";
 
@@ -19,8 +21,43 @@ interface DataTableProps<TRow extends GridValidRowModel>
   getRowId?: (row: TRow) => string | number;
   onRowClick?: (row: TRow) => void;
   isRowSelectable?: (row: TRow) => boolean;
+  /**
+   * Set it when the feeding query failed. A failed fetch leaves `rows` empty, and the grid's
+   * own overlay would then say "No rows" - which is a claim about the data, not about the fetch.
+   */
+  errorTitle?: string;
+  onRetry?: () => void;
   /** Replaces the grid's "No rows" overlay, so every empty table reads like the rest of the app. */
   emptyMessage?: string;
+}
+
+// The grid passes slot props through this interface; without the augmentation our two extra
+// props are not assignable to `noRowsOverlay`.
+declare module "@mui/x-data-grid" {
+  interface NoRowsOverlayPropsOverrides {
+    errorTitle?: string;
+    onRetry?: () => void;
+  }
+}
+
+type LoadErrorOverlayProps = HTMLAttributes<HTMLDivElement> & NoRowsOverlayPropsOverrides;
+
+function LoadErrorOverlay(props: LoadErrorOverlayProps): ReactElement {
+  const { errorTitle, onRetry } = props;
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{ alignItems: "center", justifyContent: "center", height: "100%" }}
+    >
+      <Typography variant="body2Muted">{errorTitle}</Typography>
+      {onRetry && (
+        <Button variant="text" size="small" onClick={onRetry}>
+          Retry
+        </Button>
+      )}
+    </Stack>
+  );
 }
 
 /**
@@ -30,22 +67,39 @@ interface DataTableProps<TRow extends GridValidRowModel>
 export function DataTable<TRow extends GridValidRowModel>(
   props: DataTableProps<TRow>,
 ): ReactElement {
-  const { rows, columns, getRowId, onRowClick, isRowSelectable, emptyMessage, slots, ...rest } =
-    props;
+  const {
+    rows,
+    columns,
+    getRowId,
+    onRowClick,
+    isRowSelectable,
+    errorTitle,
+    onRetry,
+    emptyMessage,
+    slots,
+    ...rest
+  } = props;
 
+  // An error outranks an empty message: a failed fetch also leaves `rows` empty, and the emptiness
+  // copy would then be a claim about the data rather than about the fetch.
   // A fresh slot component each render would remount the overlay instead of updating it.
-  const mergedSlots = useMemo(
-    () =>
-      emptyMessage
-        ? { noRowsOverlay: () => <EmptyState variant="inline" title={emptyMessage} />, ...slots }
-        : slots,
-    [emptyMessage, slots],
-  );
+  const mergedSlots = useMemo(() => {
+    if (errorTitle) {
+      return { ...slots, noRowsOverlay: LoadErrorOverlay };
+    }
+    return emptyMessage
+      ? { noRowsOverlay: () => <EmptyState variant="inline" title={emptyMessage} />, ...slots }
+      : slots;
+  }, [errorTitle, emptyMessage, slots]);
+  const slotProps = errorTitle
+    ? { ...rest.slotProps, noRowsOverlay: { errorTitle, onRetry } }
+    : rest.slotProps;
 
   return (
     <DataGrid<TRow>
       {...rest}
       slots={mergedSlots}
+      slotProps={slotProps}
       rows={rows}
       columns={columns}
       getRowId={getRowId}


### PR DESCRIPTION
## The problem

When a list query fails, `rows` is empty and the grid renders its "No rows" overlay. That is a claim about the data — the user reads "you have no cover letters" when the truth is "we could not fetch them", and there is nothing to retry from.

`QuerySection` already draws this distinction for non-grid surfaces. `DataTable` had no way to.

## The change

`errorTitle` swaps the empty overlay for a failure line with an optional `onRetry`. It outranks `emptyMessage` when both are set, since an error is not an emptiness.

Cover letters is wired as the first call site (two lines) so the prop is exercised rather than shipped dead; every other table keeps today's behaviour until it opts in.

## Notes

- `NoRowsOverlayPropsOverrides` is augmented so the two extra props are assignable to the slot — that augmentation is required by the grid's typing, not incidental.
- The overlay component is defined once at module scope; passing a fresh closure per render would remount rather than update it (same reason the existing `emptyMessage` path memoizes).
- Typecheck and `biome ci` clean. No API or migration change.

## Adjacent, deliberately not in this PR

`useApiQuery`'s toast is opt-in, so a failing query today is silent unless the call site names a message — which is how the empty-looking-table case stays invisible. Flipping that default to "toast the error's own message unless the caller opts out" is a bigger product call than this PR should smuggle in, so I left it alone. Happy to open it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tQXq4YZHb4FJy6fNwbQS