### PR TITLE
fix(applications): keep blocking an exact url past the dedupe window

### DIFF
--- a/apps/api/src/modules/application/duplicate.ts
+++ b/apps/api/src/modules/application/duplicate.ts
@@ -34,8 +34,9 @@ export type AppliedDuplicate =
   | { kind: "fuzzy"; score: number; application: DuplicateApplication };
 
 /**
- * Exact URL, else fuzzy title+company. Both arms sit inside the window: postings get reposted, and
- * an unbounded URL arm blocks the repost forever with no override. Shared by `/applied/check` and
+ * Exact URL, else fuzzy title+company. Only the fuzzy arm is windowed - it is a similarity score
+ * and would otherwise accumulate false positives forever, while an exact url is the same posting
+ * however long ago it was. Shared by `/applied/check` and
  * the apply guard so advice and enforcement cannot drift apart.
  */
 export async function findAppliedDuplicate(
@@ -51,7 +52,11 @@ export async function findAppliedDuplicate(
       where: { userId_url: { userId, url } },
       select: MATCH_SELECT,
     });
-    if (exact && exact.appliedAt >= cutoff) {
+    // Deliberately unwindowed, unlike the fuzzy arm below. An exact canonical url is the same
+    // posting however long ago it was, and the costs are not symmetric: skipping a genuine repost
+    // costs one missed application, while re-applying puts a second one in an employer's inbox and
+    // cannot be taken back.
+    if (exact) {
       return { kind: "url", application: exact };
     }
   }

--- a/apps/api/src/modules/campaign/jobs/applied-guard.test.ts
+++ b/apps/api/src/modules/campaign/jobs/applied-guard.test.ts
@@ -92,8 +92,11 @@ describe("skipIfAlreadyApplied", () => {
     expect(refusal?.message).toMatch(/Already applied \(url\)/);
   });
 
-  // Postings get reposted; without a cutoff the same url 409s forever, with no override.
-  it("lets the same url through once it falls out of the window", async () => {
+  // This used to assert the opposite - that an aged url falls out of the window and may be applied
+  // to again, so a repost is not blocked forever. In practice the window reopening is what sent six
+  // real applications out twice, and a repost at the identical url is rarer than that. Whoever
+  // wants reposts re-appliable should add an explicit override, not a timer.
+  it("keeps blocking the same url however old the application is", async () => {
     const { tx, writes } = transaction([
       { ...EXISTING, appliedAt: new Date(Date.now() - 200 * DAY_MS), title: "x", company: "y" },
     ]);
@@ -105,8 +108,8 @@ describe("skipIfAlreadyApplied", () => {
       company: "Acme",
     });
 
-    expect(refusal).toBeNull();
-    expect(writes).toHaveLength(0);
+    expect(refusal).toBeInstanceOf(AlreadyAppliedError);
+    expect(writes[0]?.data).toMatchObject({ status: "skipped" });
   });
 
   // The skip commits with the caller's transaction, so the job cannot be left `approved`.
@@ -168,6 +171,49 @@ describe("skipIfAlreadyApplied", () => {
       company: "Acme",
     });
 
+    expect(refusal).toBeNull();
+  });
+});
+
+// Regression: six postings went out twice at gaps of exactly 30 and 33 days, because the exact-url
+// arm was gated on the same window as the fuzzy arm. A month-old application is still an
+// application - the employer has it, and re-applying cannot be taken back.
+describe("skipIfAlreadyApplied outside the dedupe window", () => {
+  const AGED: FakeApplication = {
+    ...EXISTING,
+    appliedAt: new Date(Date.now() - 33 * DAY_MS),
+  };
+
+  it("still blocks the same url a month later", async () => {
+    const { tx } = transaction([AGED]);
+    const refusal = await skipIfAlreadyApplied(tx, "u1", {
+      ...JOB,
+      url: AGED.url,
+      title: AGED.title,
+      company: AGED.company,
+    });
+    expect(refusal).toBeInstanceOf(AlreadyAppliedError);
+  });
+
+  it("records the aged duplicate as skipped rather than leaving it to be re-offered", async () => {
+    const { tx, writes } = transaction([AGED]);
+    await skipIfAlreadyApplied(tx, "u1", {
+      ...JOB,
+      url: AGED.url,
+      title: AGED.title,
+      company: AGED.company,
+    });
+    expect(writes[0]?.data).toMatchObject({ status: "skipped" });
+  });
+
+  it("lets a different posting through, so the unwindowed arm is url-exact and nothing wider", async () => {
+    const { tx } = transaction([AGED]);
+    const refusal = await skipIfAlreadyApplied(tx, "u1", {
+      ...JOB,
+      url: "https://example.test/jobs/2",
+      title: "Backend Engineer",
+      company: "Globex",
+    });
     expect(refusal).toBeNull();
   });
 });


### PR DESCRIPTION
## What happened

`findAppliedDuplicate` gates the exact-url arm on the same 30-day cutoff as the fuzzy arm:

```ts
if (exact && exact.appliedAt >= cutoff) {
```

So a month after applying, the identical posting becomes applicable again. On my instance that sent **six real applications out twice**, every one at a gap of exactly 30 or 33 days:

| Employer | First | Second | Gap |
|---|---|---|---|
| World Education Services | Aug 9 | Sep 8 | 30d |
| Wave | Aug 9 | Sep 8 | 30d |
| Banyan Software | Aug 9 | Sep 8 | 30d |
| Scratch Financial | Aug 9 | Sep 8 | 30d |
| UP.Labs | Aug 8 | Sep 10 | 33d |
| Talent.com | Aug 9 | Sep 10 | 33d |

The identical gap is the tell — it is the window reopening, not a scoring miss.

## The change

Unwindow the url arm; leave the fuzzy arm exactly as it is.

The two arms aren't the same kind of claim. Fuzzy title+company is a similarity score and **has** to expire or it accumulates false positives forever — that part of the current design is right. An exact canonical url is the same posting however long ago it was.

And the costs are asymmetric: skipping a genuine repost costs one missed application; re-applying puts a second one in an employer's inbox and cannot be recalled.

## On the existing rationale

The comment says: *"postings get reposted, and an unbounded URL arm blocks the repost forever with no override."* That's a fair concern and I'm not dismissing it — but the override it argues for is an *explicit* one (a user or agent saying "yes, re-apply to this"), not a timer that fires on every posting alike. As written, the timer's benefit is the occasional legitimate repost and its cost is silent duplicate applications; on my data only the cost showed up.

Happy to rework this as an explicit re-apply override instead if you'd prefer that shape.

## Notes

- One behavioural line. `bun --cwd=apps/api run test` passes (572); the test that asserted the windowed url arm now asserts the unwindowed one, and three new cases cover the aged duplicate.
- No migration, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tQXq4YZHb4FJy6fNwbQS